### PR TITLE
Fixed bug for invalid url

### DIFF
--- a/android-volley.iml
+++ b/android-volley.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android" name="Android">
+      <configuration />
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>
+

--- a/src/com/android/volley/Request.java
+++ b/src/com/android/volley/Request.java
@@ -23,6 +23,7 @@ import android.os.Looper;
 import android.os.SystemClock;
 import android.text.TextUtils;
 
+import android.webkit.URLUtil;
 import com.android.volley.VolleyLog.MarkerLog;
 
 import java.io.UnsupportedEncodingException;
@@ -126,7 +127,20 @@ public abstract class Request<T> implements Comparable<Request<T>> {
         mErrorListener = listener;
         setRetryPolicy(new DefaultRetryPolicy());
 
-        mDefaultTrafficStatsTag = TextUtils.isEmpty(url) ? 0: Uri.parse(url).getHost().hashCode();
+        final Uri uri = parseUrl(url);
+        if(uri != null) {
+            mDefaultTrafficStatsTag = uri.getHost().hashCode();
+        } else {
+            mDefaultTrafficStatsTag = 0;
+        }
+    }
+
+    private Uri parseUrl(final String url) {
+        if(URLUtil.isValidUrl(url)) {
+            final Uri uri = Uri.parse(url);
+            return uri;
+        }
+        return null;
     }
 
     /**

--- a/src/com/android/volley/toolbox/NetworkImageView.java
+++ b/src/com/android/volley/toolbox/NetworkImageView.java
@@ -113,14 +113,14 @@ public class NetworkImageView extends ImageView {
             return;
         }
 
-        // if the URL to be loaded in this view is empty, cancel any old requests and clear the
-        // currently loaded image.
+        // if the URL to be loaded in this view is empty, cancel any old requests
+        // and set the error image.
         if (TextUtils.isEmpty(mUrl)) {
             if (mImageContainer != null) {
                 mImageContainer.cancelRequest();
                 mImageContainer = null;
             }
-            setImageBitmap(null);
+            setImageDrawable(getResources().getDrawable(mErrorImageId));
             return;
         }
 

--- a/tests/tests.iml
+++ b/tests/tests.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android" name="Android">
+      <configuration />
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>
+


### PR DESCRIPTION
Using the method setImageUrl(...) of NetworkImageView caused a NullPointerException when the url was invalid (e.g. url = "v"). I fixed that. 
Also using the same method with a url that is null caused that no image was set (neither the previously set default image nor error image). 
Sorry for the 2 .iml files, was an accident.
