### PR TITLE
fixed PATCH request

### DIFF
--- a/src/com/android/volley/toolbox/HttpClientStack.java
+++ b/src/com/android/volley/toolbox/HttpClientStack.java
@@ -166,15 +166,21 @@ public class HttpClientStack implements HttpStack {
      */
     public static final class HttpPatch extends HttpEntityEnclosingRequestBase {
 
-        public final static String METHOD_NAME = "PATCH";
+        // HTTPUrlConnection does not support PATCH.
+        // make POST request and override http method in header
+
+        public final static String METHOD_NAME = "POST";
+        public final static String METHOD_OVERRIDE = "PATCH";
 
         public HttpPatch() {
             super();
+            addHeader(HEADER_X_HTTP_METHOD_OVERRIDE, METHOD_OVERRIDE);
         }
 
         public HttpPatch(final URI uri) {
             super();
             setURI(uri);
+            addHeader(HEADER_X_HTTP_METHOD_OVERRIDE, METHOD_OVERRIDE);
         }
 
         /**

--- a/src/com/android/volley/toolbox/HttpStack.java
+++ b/src/com/android/volley/toolbox/HttpStack.java
@@ -28,6 +28,9 @@ import java.util.Map;
  * An HTTP stack abstraction.
  */
 public interface HttpStack {
+
+    String HEADER_X_HTTP_METHOD_OVERRIDE = "X-HTTP-Method-Override";
+
     /**
      * Performs an HTTP request with the given parameters.
      *

--- a/src/com/android/volley/toolbox/HurlStack.java
+++ b/src/com/android/volley/toolbox/HurlStack.java
@@ -225,6 +225,7 @@ public class HurlStack implements HttpStack {
             case Method.PATCH:
                 addBodyIfExists(connection, request);
                 connection.setRequestMethod("PATCH");
+                connection.addRequestProperty(HEADER_X_HTTP_METHOD_OVERRIDE, "PATCH");
                 break;
             default:
                 throw new IllegalStateException("Unknown method type.");


### PR DESCRIPTION
HTTPUrlConnection does not support PATCH and fires exception.
Instead of using PATCH method directly in Request, should be used POST method with header "X-HTTP-Method-Override : PATCH". Then PATCH method works fine.
