### PR TITLE
added support for handling 301 and 302 http redirects

### DIFF
--- a/src/com/android/volley/Request.java
+++ b/src/com/android/volley/Request.java
@@ -68,6 +68,9 @@ public abstract class Request<T> implements Comparable<Request<T>> {
 
     /** URL of this request. */
     private final String mUrl;
+    
+    /** The redirect url to use for 3xx http responses */
+    private String mRedirectUrl;
 
     /** Default tag for {@link TrafficStats}. */
     private final int mDefaultTrafficStatsTag;
@@ -261,7 +264,21 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      * Returns the URL of this request.
      */
     public String getUrl() {
-        return mUrl;
+        return (mRedirectUrl != null) ? mRedirectUrl : mUrl;
+    }
+    
+    /**
+     * Returns the URL of the request before any redirects have occurred.
+     */
+    public String getOriginUrl() {
+    	return mUrl;
+    }
+    
+    /**
+     * Sets the redirect url to handle 3xx http responses.
+     */
+    public void setRedirectUrl(String redirectUrl) {
+    	mRedirectUrl = redirectUrl;
     }
 
     /**

--- a/src/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/com/android/volley/toolbox/BasicNetwork.java
@@ -101,6 +101,12 @@ public class BasicNetwork implements Network {
                             request.getCacheEntry() == null ? null : request.getCacheEntry().data,
                             responseHeaders, true);
                 }
+                
+                // Handle moved resources
+                if (statusCode == HttpStatus.SC_MOVED_PERMANENTLY || statusCode == HttpStatus.SC_MOVED_TEMPORARILY) {
+                	String newUrl = responseHeaders.get("Location");
+                	request.setRedirectUrl(newUrl);
+                }
 
                 // Some responses such as 204s do not have content.  We must check.
                 if (httpResponse.getEntity() != null) {
@@ -133,13 +139,22 @@ public class BasicNetwork implements Network {
                 } else {
                     throw new NoConnectionError(e);
                 }
-                VolleyLog.e("Unexpected response code %d for %s", statusCode, request.getUrl());
+                if (statusCode == HttpStatus.SC_MOVED_PERMANENTLY || 
+                		statusCode == HttpStatus.SC_MOVED_TEMPORARILY) {
+                	VolleyLog.e("Request at %s has been redirected to %s", request.getOriginUrl(), request.getUrl());
+                } else {
+                	VolleyLog.e("Unexpected response code %d for %s", statusCode, request.getUrl());
+                }
                 if (responseContents != null) {
                     networkResponse = new NetworkResponse(statusCode, responseContents,
                             responseHeaders, false);
                     if (statusCode == HttpStatus.SC_UNAUTHORIZED ||
                             statusCode == HttpStatus.SC_FORBIDDEN) {
                         attemptRetryOnException("auth",
+                                request, new AuthFailureError(networkResponse));
+                    } else if (statusCode == HttpStatus.SC_MOVED_PERMANENTLY || 
+                    			statusCode == HttpStatus.SC_MOVED_TEMPORARILY) {
+                        attemptRetryOnException("redirect",
                                 request, new AuthFailureError(networkResponse));
                     } else {
                         // TODO: Only throw ServerError for 5xx status codes.


### PR DESCRIPTION
Volley was not handling 301 or 302 redirects, these common status codes should be handled by the library.

http://stackoverflow.com/questions/17481964/android-volley-to-handle-redirect
http://stackoverflow.com/questions/19787999/unexpected-response-code-302-for-volley-image-request
