### PR TITLE
Fixed a bug where an error 403 was attempting a retry instead of returning a NetworkResponse

### DIFF
--- a/src/com/android/volley/VolleyLog.java
+++ b/src/com/android/volley/VolleyLog.java
@@ -62,6 +62,10 @@ public class VolleyLog {
     public static void e(Throwable tr, String format, Object... args) {
         Log.e(TAG, buildMessage(format, args), tr);
     }
+    
+    public static void i(String format, Object... args) {
+    	Log.i(TAG, buildMessage(format, args));
+    }
 
     public static void wtf(String format, Object... args) {
         Log.wtf(TAG, buildMessage(format, args));

--- a/src/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/com/android/volley/toolbox/BasicNetwork.java
@@ -121,7 +121,7 @@ public class BasicNetwork implements Network {
                 long requestLifetime = SystemClock.elapsedRealtime() - requestStart;
                 logSlowRequests(requestLifetime, request, responseContents, statusLine);
 
-                if (statusCode < 200 || statusCode > 299) {
+                if ((statusCode < 200 || statusCode > 299) && statusCode != 403) {
                     throw new IOException();
                 }
                 return new NetworkResponse(statusCode, responseContents, responseHeaders, false);
@@ -141,7 +141,7 @@ public class BasicNetwork implements Network {
                 }
                 if (statusCode == HttpStatus.SC_MOVED_PERMANENTLY || 
                 		statusCode == HttpStatus.SC_MOVED_TEMPORARILY) {
-                	VolleyLog.e("Request at %s has been redirected to %s", request.getOriginUrl(), request.getUrl());
+                	VolleyLog.i("Request at %s has been redirected to %s", request.getOriginUrl(), request.getUrl());
                 } else {
                 	VolleyLog.e("Unexpected response code %d for %s", statusCode, request.getUrl());
                 }


### PR DESCRIPTION
It is impossible for the current implementation of volley to return an error 403, BasicNetwork attempts a retry instead of returning a NetworkResponse.
