### PR TITLE
fixed bug where Disk cache misses for redirects because while the lookup...

### DIFF
--- a/src/com/android/volley/Request.java
+++ b/src/com/android/volley/Request.java
@@ -301,7 +301,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      * Returns the cache key for this request.  By default, this is the URL.
      */
     public String getCacheKey() {
-        return getUrl();
+        return getOriginUrl();
     }
 
     /**


### PR DESCRIPTION
... is (obviously) using the original url as the key, storing to Disk was wrongfully using the redirect url as cache key
