### PR TITLE
Add a getImageURL method

### DIFF
--- a/src/com/android/volley/toolbox/NetworkImageView.java
+++ b/src/com/android/volley/toolbox/NetworkImageView.java
@@ -79,6 +79,16 @@ public class NetworkImageView extends ImageView {
         // The URL has potentially changed. See if we need to load it.
         loadImageIfNecessary(false);
     }
+    
+    /**
+     * Gets the URL of the image that should be loaded into this view, or null if no URL has been set.
+     * The image may or may not already be downloaded and set into the view.
+     * @return the URL of the image to be set into the view, or null.
+     */
+    public String getImageURL()
+    {
+    	return mUrl;
+    }
 
     /**
      * Sets the default image resource ID to be used for this view until the attempt to load it


### PR DESCRIPTION
Adds a method that allows a user to get the URL of the image set in the NetworkImageView.
This, for example, may be useful to check if a NetworkImageView has an image defined to be loaded with only access to the view itself. It may be necessary when the user doesn't have access to the original URL in their scope.
