### PR TITLE
Add the options of setting DiskBasedCache sizes in Volley.java

### DIFF
--- a/src/main/java/com/android/volley/toolbox/Volley.java
+++ b/src/main/java/com/android/volley/toolbox/Volley.java
@@ -34,12 +34,14 @@ public class Volley {
 
     /**
      * Creates a default instance of the worker pool and calls {@link RequestQueue#start()} on it.
+     * You may set a maximum size of the disk cache in bytes.
      *
      * @param context A {@link Context} to use for creating the cache dir.
      * @param stack An {@link HttpStack} to use for the network, or null for default.
+     * @param maxDiskCacheBytes the maximum size of the disk cache, in bytes. Use -1 for default size.
      * @return A started {@link RequestQueue} instance.
      */
-    public static RequestQueue newRequestQueue(Context context, HttpStack stack) {
+    public static RequestQueue newRequestQueue(Context context, HttpStack stack, int maxDiskCacheBytes) {
         File cacheDir = new File(context.getCacheDir(), DEFAULT_CACHE_DIR);
 
         String userAgent = "volley/0";
@@ -61,13 +63,48 @@ public class Volley {
         }
 
         Network network = new BasicNetwork(stack);
+        
+        RequestQueue queue;
+        if (maxDiskCacheBytes <= -1)
+        {
+        	// No maximum size specified
+        	queue = new RequestQueue(new DiskBasedCache(cacheDir), network);
+        }
+        else
+        {
+        	// Disk cache size specified
+        	queue = new RequestQueue(new DiskBasedCache(cacheDir, maxDiskCacheBytes), network);
+        }
 
-        RequestQueue queue = new RequestQueue(new DiskBasedCache(cacheDir), network);
         queue.start();
 
         return queue;
     }
-
+    
+    /**
+     * Creates a default instance of the worker pool and calls {@link RequestQueue#start()} on it.
+     * You may set a maximum size of the disk cache in bytes.
+     *
+     * @param context A {@link Context} to use for creating the cache dir.
+     * @param maxDiskCacheBytes the maximum size of the disk cache, in bytes. Use -1 for default size.
+     * @return A started {@link RequestQueue} instance.
+     */
+    public static RequestQueue newRequestQueue(Context context, int maxDiskCacheBytes) {
+        return newRequestQueue(context, null, maxDiskCacheBytes);
+    }
+    
+    /**
+     * Creates a default instance of the worker pool and calls {@link RequestQueue#start()} on it.
+     *
+     * @param context A {@link Context} to use for creating the cache dir.
+     * @param stack An {@link HttpStack} to use for the network, or null for default.
+     * @return A started {@link RequestQueue} instance.
+     */
+    public static RequestQueue newRequestQueue(Context context, HttpStack stack)
+    {
+    	return newRequestQueue(context, stack, -1);
+    }
+    
     /**
      * Creates a default instance of the worker pool and calls {@link RequestQueue#start()} on it.
      *
@@ -77,4 +114,6 @@ public class Volley {
     public static RequestQueue newRequestQueue(Context context) {
         return newRequestQueue(context, null);
     }
+
 }
+


### PR DESCRIPTION
The default DiskBasedCache size of 5MB is not appropriate for all users of volley.
There is no interface for users to set this size when using the standard volley implementation. Before this change, one would need to fork their own Volley.java file to be able to change the size of the DiskBasedCache.
