### PR TITLE
Fix synchronizition issue

### DIFF
--- a/src/main/java/com/android/volley/toolbox/NetworkImageView.java
+++ b/src/main/java/com/android/volley/toolbox/NetworkImageView.java
@@ -18,7 +18,6 @@ package com.android.volley.toolbox;
 import android.content.Context;
 import android.text.TextUtils;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.ImageView;
 
@@ -150,8 +149,6 @@ public class NetworkImageView extends ImageView {
 					// if the request is from the same URL, return.
 					return;
 				} else {
-					Log.d("urls", mImageContainer.getRequestUrl() + " new "
-							+ mUrl);
 					// if there is a pre-existing request, cancel it if it's
 					// fetching a different URL.
 					mImageContainer.cancelRequest();


### PR DESCRIPTION
NetworkImageView have a problem when it works with cache
senario
image1 and image2 Respectively
image2 available on cache and image1 not available
what was happened is fetching imag1 from internet imag2 fetched fast from cache
after finish loading image1 it sets over image2 and the last result imag1 and url of image2 -mImageContainer-
