### PR TITLE
NegativeArraySizeException

### DIFF
--- a/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
@@ -121,6 +121,10 @@ public class DiskBasedCache implements Cache {
             VolleyLog.d("%s: %s", file.getAbsolutePath(), e.toString());
             remove(key);
             return null;
+        }  catch (NegativeArraySizeException e) {
+            VolleyLog.d("%s: %s", file.getAbsolutePath(), e.toString());
+            remove(key);
+            return null;
         } finally {
             if (cis != null) {
                 try {


### PR DESCRIPTION
As also suggested here: https://groups.google.com/forum/#!topic/volley-users/0W-oI6za8VY

We will also catch NegativeArraySizeException in addition to IOException when attempting to get an Entry from the cache. This exception may be caused by the file being deleted by the OS after we created the CountingInputStream