### PR TITLE
Volley 401 status-code fix. 

### DIFF
--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -106,7 +106,16 @@ public class HurlStack implements HttpStack {
         setConnectionParametersForRequest(connection, request);
         // Initialize HttpResponse with data from the HttpURLConnection.
         ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
-        int responseCode = connection.getResponseCode();
+
+        // Retrying to get the status can return a 401 status as it will be
+        // updated internally at that point.
+        int responseCode;
+        try {
+            responseCode = connection.getResponseCode();
+        } catch (IOException e) {
+            responseCode = connection.getResponseCode();
+        }
+
         if (responseCode == -1) {
             // -1 is returned by getResponseCode() if the response code could not be retrieved.
             // Signal to the caller that something was wrong with the connection.


### PR DESCRIPTION
This fixes the issue where java.net.HttpURLConnection.getResponseCode() throws an IOException when the server returns a 401 status. 

I've added what seems to be the JDK accepted work-around for this issue. See:
https://bugs.openjdk.java.net/browse/JDK-4191815
and
http://stackoverflow.com/questions/11735636/how-to-get-401-response-without-handling-it-using-try-catch-in-android
