### PR TITLE
[fix] leaking the last request object after request queue is drained

### DIFF
--- a/src/main/java/com/android/volley/NetworkDispatcher.java
+++ b/src/main/java/com/android/volley/NetworkDispatcher.java
@@ -82,9 +82,11 @@ public class NetworkDispatcher extends Thread {
     @Override
     public void run() {
         Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND);
+        Request<?> request;
         while (true) {
             long startTimeMs = SystemClock.elapsedRealtime();
-            Request<?> request;
+            // release previous request object to avoid leaking request object when mQueue is drained.
+            request = null;
             try {
                 // Take a request from the queue.
                 request = mQueue.take();


### PR DESCRIPTION
# description:
  this leak can be detected by LeakCanary, see

  > D/LeakCanary﹕ In io.github.pandacast:1.1:2.
  > D/LeakCanary﹕ * io.github.pandacast.MainActivity has leaked:
  > D/LeakCanary﹕ * GC ROOT thread com.android.volley.NetworkDispatcher.<Java Local> (named 'Thread-5690')
  > D/LeakCanary﹕ * references io.github.pandacast.model.RestClient$LiveListRequest.mListener
  > D/LeakCanary﹕ * references io.github.pandacast.LiveListFragment$LiveListAdapter.mContext
  > D/LeakCanary﹕ * leaks io.github.pandacast.MainActivity instance

# root cause:
  In `NetworkDispatcher.run()` , the local variable `request` hold
  the last Request object. If there is no more Request object in
  `mQueue`, `request = mQueue.take();` in line 90 would **block**
  until new Request object enqueue, which cause the leak of last
  Request object.

  In common practice, Request has strong reference to Listener and
  Listener is either implemented by Activity or referenced by
  Activity as instance of inner class which implement Listener.
  Thus cause leaking the whole Activity instance.

# how to fix:
  set request to **null** before `request = mQueue.take();`