### PR TITLE
[fix] leaking the last request object in CacheDispatcher

### DIFF
--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -83,11 +83,15 @@ public class CacheDispatcher extends Thread {
         // Make a blocking call to initialize the cache.
         mCache.initialize();
 
+        Request<?> request;
         while (true) {
             try {
+                // release previous request object to avoid leaking request object
+		request = null;
+
                 // Get a request from the cache triage queue, blocking until
                 // at least one is available.
-                final Request<?> request = mCacheQueue.take();
+                request = mCacheQueue.take();
                 request.addMarker("cache-queue-take");
 
                 // If the request has been canceled, don't bother dispatching it.
@@ -134,11 +138,12 @@ public class CacheDispatcher extends Thread {
 
                     // Post the intermediate response back to the user and have
                     // the delivery then forward the request along to the network.
+                    final Request<?> forwardRequest = request;
                     mDelivery.postResponse(request, response, new Runnable() {
                         @Override
                         public void run() {
                             try {
-                                mNetworkQueue.put(request);
+                                mNetworkQueue.put(forwardRequest);
                             } catch (InterruptedException e) {
                                 // Not much we can do about this.
                             }


### PR DESCRIPTION
Similar to PR #64 as I think issue still exist in CacheDispatcher.