### PR TITLE
Original request in Retry Policy

### DIFF
--- a/src/main/java/com/android/volley/DefaultRetryPolicy.java
+++ b/src/main/java/com/android/volley/DefaultRetryPolicy.java
@@ -89,7 +89,7 @@ public class DefaultRetryPolicy implements RetryPolicy {
      * @param error The error code of the last attempt.
      */
     @Override
-    public void retry(VolleyError error) throws VolleyError {
+    public void retry(VolleyError error, Request request) throws VolleyError {
         mCurrentRetryCount++;
         mCurrentTimeoutMs += (mCurrentTimeoutMs * mBackoffMultiplier);
         if (!hasAttemptRemaining()) {

--- a/src/main/java/com/android/volley/RetryPolicy.java
+++ b/src/main/java/com/android/volley/RetryPolicy.java
@@ -34,8 +34,9 @@ public interface RetryPolicy {
     /**
      * Prepares for the next retry by applying a backoff to the timeout.
      * @param error The error code of the last attempt.
+     * @param request The request that caused the retry.
      * @throws VolleyError In the event that the retry could not be performed (for example if we
      * ran out of attempts), the passed in error is thrown.
      */
-    public void retry(VolleyError error) throws VolleyError;
+    public void retry(VolleyError error, Request request) throws VolleyError;
 }

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -209,7 +209,7 @@ public class BasicNetwork implements Network {
         int oldTimeout = request.getTimeoutMs();
 
         try {
-            retryPolicy.retry(exception);
+            retryPolicy.retry(exception, request);
         } catch (VolleyError e) {
             request.addMarker(
                     String.format("%s-timeout-giveup [timeout=%s]", logPrefix, oldTimeout));


### PR DESCRIPTION
Passing the request object to ‘retry’ method for Retry Policy classes.
Given an opportunity to handle an error-retry custom policy with a
request.setRedirectUrl()