### PR TITLE
fix missing headers with multiple values

### DIFF
--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -121,7 +121,14 @@ public class HurlStack implements HttpStack {
         }
         for (Entry<String, List<String>> header : connection.getHeaderFields().entrySet()) {
             if (header.getKey() != null) {
-                Header h = new BasicHeader(header.getKey(), header.getValue().get(0));
+                String value = "";
+                for(String head : header.getValue()){
+                    value += head + ";";
+                }
+                if(value.length() > 0)
+                    value = value.substring(0,value.length() - 1);
+
+                Header h = new BasicHeader(header.getKey(), value);
                 response.addHeader(h);
             }
         }


### PR DESCRIPTION
hey there
in some responses headers we have multiple **Set-Cookie** headers.
volley always consider first value of these type of headers :
```
Header h = new BasicHeader(header.getKey(), header.getValue().get(0));
```
My solution is that we shouldn't consider only first item of `header.getValue()`. we should merge all values in array with `;`

for more info about this bug and example see [this](https://github.com/mcxiaoke/android-volley/issues/126)
