### PR TITLE
除去 request.markDelivered();

### DIFF
--- a/src/main/java/com/android/volley/NetworkDispatcher.java
+++ b/src/main/java/com/android/volley/NetworkDispatcher.java
@@ -133,7 +133,6 @@ public class NetworkDispatcher extends Thread {
                 }
 
                 // Post the response back.
-                request.markDelivered();
                 mDelivery.postResponse(request, response);
             } catch (VolleyError volleyError) {
                 volleyError.setNetworkTimeMs(SystemClock.elapsedRealtime() - startTimeMs);


### PR DESCRIPTION
因为request.markDelivered();在mDelivery.postResponse(request, response);已经调用了