### PR TITLE
Fix for [#139] OOM exception while using HEAD request

### DIFF
--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -126,7 +126,7 @@ public class BasicNetwork implements Network {
                 }
 
                 // Some responses such as 204s do not have content.  We must check.
-                if (httpResponse.getEntity() != null) {
+                if (httpResponse.getEntity() != null && request.getMethod() != Request.Method.HEAD) {
                   responseContents = entityToBytes(httpResponse.getEntity());
                 } else {
                   // Add 0 byte response as a way of honestly representing a


### PR DESCRIPTION
Memory should not be allocated based on Content length header for HEAD request.
responseContents = new byte[0]; 
should be used for HEAD requests to avoid using device memory.

It is possible to test the issue with HEAD method against huge PDF file (~100-150 Mb). Such request usually end up with OOM exception. With this fix it will get back with reponse very fast and without using extra memory.